### PR TITLE
Rate limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,17 @@ A channel will be archived by this script is it doesn't meet any of the followin
 ## What Happens When A Channel Is Archived By This Script
 
 - *Don't panic! It can be unarchived by following [these instructions](https://slack.com/intl/en-ca/help/articles/201563847#unarchive-a-channel) However all previous members would be kicked out of the channel and not be automatically invited back.
-- A message will be dropped into the channel saying the channel is being auto archived because of low activity
 - You can always whitelist a channel if it indeed needs to be kept despite meeting the auto-archive criteria.
 
-## Custom Archive Messages
+## I don't trust the DRY_RUN option to not mess up Slack environmnet or cause confusion amongst my user.
 
-Just before a channel is archived, a message will be sent with information about the archive process. The default message is:
-
-  This channel has had no activity for %s days. It is being auto-archived. If you feel this is a mistake you can <https://get.slack.help/hc/en-us/articles/201563847-Archive-a-channel#unarchive-a-channel|unarchive this channel> to bring it back at any point.'
-
-To provide a custom message, simply edit `templates.json`.
+Create a new Slack org to test this script against. Use the create_test_channels.py script to quickly create channels in your new Slack org. Edit create_test_channels.py to change the number of channels to create.
 
 ## Known Issues
 
 - Since slack doesn't have a batch API, we have to hit the api a couple times for each channel. This makes the performance of this script slow. If you have thousands of channels (which some people do), get some coffee and be patient.
+
+- Channels, such as #general, that aren't archivable is reported as being archived. This can be ignored.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A channel will be archived by this script is it doesn't meet any of the followin
 - *Don't panic! It can be unarchived by following [these instructions](https://slack.com/intl/en-ca/help/articles/201563847#unarchive-a-channel) However all previous members would be kicked out of the channel and not be automatically invited back.
 - You can always whitelist a channel if it indeed needs to be kept despite meeting the auto-archive criteria.
 
-## I don't trust the DRY_RUN option to not mess up Slack environmnet or cause confusion amongst my user.
+## I don't trust the DRY_RUN option to not mess up my Slack org or cause confusion amongst my users.
 
 Create a new Slack org to test this script against. Use the create_test_channels.py script to quickly create channels in your new Slack org. Edit create_test_channels.py to change the number of channels to create.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Create a new Slack org to test this script against. Use the create_test_channels
 
 - Since slack doesn't have a batch API, we have to hit the api a couple times for each channel. This makes the performance of this script slow. If you have thousands of channels (which some people do), get some coffee and be patient.
 
-- Channels, such as #general, that aren't archivable are reported as being archived. This can be ignored.
+- Channels that aren't archivable, such as #general, are reported as being archived. This can be ignored.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Create a new Slack org to test this script against. Use the create_test_channels
 
 - Since slack doesn't have a batch API, we have to hit the api a couple times for each channel. This makes the performance of this script slow. If you have thousands of channels (which some people do), get some coffee and be patient.
 
-- Channels, such as #general, that aren't archivable is reported as being archived. This can be ignored.
+- Channels, such as #general, that aren't archivable are reported as being archived. This can be ignored.
 
 ## Docker
 

--- a/create_test_channels.py
+++ b/create_test_channels.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""
+Super quick way to create empty channels in a Slack org.
+Intended purpose is to try slack-autoarchive in a test org without
+worrying about messing up your current channels or inflicting confusion
+to your users.
+
+There's a decent chance slack-autoarchive is broken given the last time
+the slack-archive was updated or when Slack updated their product.
+"""
+
+import json
+import os
+import requests
+import time
+from dotenv import load_dotenv
+
+load_dotenv()
+
+number_channels = 50
+channel_name_prefix = 'an-interesting-channel'
+
+def slack_api(api_endpoint, payload):
+    uri = f'https://slack.com/api/{api_endpoint}'
+    header = {'Authorization': f'Bearer {os.environ.get("BOT_SLACK_TOKEN")}'}
+
+    try:
+        resp = requests.post(uri, headers=header, data=payload)
+    except requests.exceptions.RequestException as e:
+        print('Something unexpected happened...')
+        SystemExit(e)
+
+    if resp.status_code == requests.codes.too_many_requests:
+        timeout = int(resp.headers['retry-after']) + 3
+        print(f'rate-limited: Trying again in {timeout} seconds.')
+        time.sleep(timeout)
+        return slack_api(api_endpoint, payload)
+    else:
+        return resp
+
+
+if __name__ == '__main__':
+    if os.environ.get('BOT_SLACK_TOKEN', False) == False:
+      print('Need to set BOT_SLACK_TOKEN before running this program.\n\n' \
+            'Either set it in .env or run this script as:\n' \
+            'BOT_SLACK_TOKEN=<secret token> python create_test_channels.py')
+      exit(1)
+      
+    for x in range(number_channels):
+        channel_name = f'{channel_name_prefix}-{x}'
+        payload = {'name': channel_name}
+        print(f'Creating channel: {channel_name}')
+        resp = slack_api('conversations.create', payload)
+        response = resp.json()
+
+        if response['ok']:
+            payload = {'channel': response['channel']['id']}
+            resp_leave = slack_api('conversations.leave', payload)
+
+            if not resp_leave.json()['ok']:
+                print(f'Error removing the bot from #{channel_name}: '\
+                      f'{resp_leave.json()["error"]}')
+        else:
+            print(response)
+            print(response['error'])

--- a/create_test_channels.py
+++ b/create_test_channels.py
@@ -14,30 +14,12 @@ import os
 import requests
 import time
 from dotenv import load_dotenv
+from slack_autoarchive import ChannelReaper
 
 load_dotenv()
-
+cr = ChannelReaper()
 number_channels = 50
 channel_name_prefix = 'an-interesting-channel'
-
-def slack_api(api_endpoint, payload):
-    uri = f'https://slack.com/api/{api_endpoint}'
-    header = {'Authorization': f'Bearer {os.environ.get("BOT_SLACK_TOKEN")}'}
-
-    try:
-        resp = requests.post(uri, headers=header, data=payload)
-    except requests.exceptions.RequestException as e:
-        print('Something unexpected happened...')
-        SystemExit(e)
-
-    if resp.status_code == requests.codes.too_many_requests:
-        timeout = int(resp.headers['retry-after']) + 3
-        print(f'rate-limited: Trying again in {timeout} seconds.')
-        time.sleep(timeout)
-        return slack_api(api_endpoint, payload)
-    else:
-        return resp
-
 
 if __name__ == '__main__':
     if os.environ.get('BOT_SLACK_TOKEN', False) == False:
@@ -50,16 +32,14 @@ if __name__ == '__main__':
         channel_name = f'{channel_name_prefix}-{x}'
         payload = {'name': channel_name}
         print(f'Creating channel: {channel_name}')
-        resp = slack_api('conversations.create', payload)
-        response = resp.json()
+        resp = cr.slack_api_http('conversations.create', payload, 'POST')
 
-        if response['ok']:
-            payload = {'channel': response['channel']['id']}
-            resp_leave = slack_api('conversations.leave', payload)
+        if resp['ok']:
+            payload = {'channel': resp['channel']['id']}
+            resp_leave = cr.slack_api_http('conversations.leave', payload, 'POST')
 
-            if not resp_leave.json()['ok']:
+            if not resp_leave['ok']:
                 print(f'Error removing the bot from #{channel_name}: '\
                       f'{resp_leave.json()["error"]}')
         else:
-            print(response)
-            print(response['error'])
+            print(resp)


### PR DESCRIPTION
Added create_test_channels.py to quickly create channels in a test org to try out slack-autoarchive.

Streamlined slack_api_http() to not fail when being rate limited.

Increase the the chattiness of the app quite a bit so the Slack admin running the program and see the status of the program - is the program doing something or is it stuck?

updated the parameters of join_channel() to match archive_channel()